### PR TITLE
ログイン機能の実装

### DIFF
--- a/server/web/src/integrationTest/resources/application.yml
+++ b/server/web/src/integrationTest/resources/application.yml
@@ -1,4 +1,7 @@
 app:
+  api:
+    password:
+      bcrypt-strength: 10
   gateway:
     env:
       system-setting:

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength.kt
@@ -1,0 +1,26 @@
+﻿package walter.y.bookeye.web.domain.password
+
+class PasswordStrength(
+    value: Int?
+) {
+    val value = kotlin.run {
+        requireNotNull(value) { "passwordStrength should be not null" }
+        require(value in MIN..MAX) { "passwordStrength should be $MIN to $MAX" }
+        value
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is PasswordStrength) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value
+    }
+
+    companion object {
+        const val MIN = 4
+        const val MAX = 31
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName.kt
@@ -1,0 +1,51 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+/**
+ * RFC 7504
+ * - 参考: https://qiita.com/yoshitake_1201/items/40268332cd23f67c504c
+ */
+class PrincipalName(
+    value: String?
+) {
+    val value = kotlin.run {
+        requireNotNull(value) { "principalName should not be null" }
+        val trimmedValue = value.trim()
+        require(trimmedValue.isNotEmpty()) { "principalName should not be blank" }
+        require(trimmedValue.length in MIN_LENGTH..MAX_LENGTH) {
+            "principalName should be $MIN_LENGTH to $MAX_LENGTH characters"
+        }
+
+        require(trimmedValue.contains(ADDRESS_SEPARATOR)) {
+            "principalName should contain $ADDRESS_SEPARATOR"
+        }
+
+        val (localPart, domain) = trimmedValue.split(ADDRESS_SEPARATOR)
+        require(localPart.length in LOCAL_PART_MIN_LENGTH..LOCAL_PART_MAX_LENGTH) {
+            "principalName should have local-part in $LOCAL_PART_MIN_LENGTH..$LOCAL_PART_MAX_LENGTH"
+        }
+        require(domain.isNotEmpty()) { "principalName should have domain part" }
+        require(Regex(PATTERN).matches(trimmedValue)) { "principalName should be pattern of `$PATTERN`" }
+        trimmedValue
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is PrincipalName) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    companion object {
+        private const val MIN_LENGTH = 8
+        private const val MAX_LENGTH = 254
+        private const val LOCAL_PART_MIN_LENGTH = 1
+        private const val LOCAL_PART_MAX_LENGTH = 64
+        private const val ADDRESS_SEPARATOR = "@"
+        private const val LOCAL_PART_PATTERN = """(?i)[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*"""
+        private const val DOMAIN_PATTERN = """(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?"""
+        private const val PATTERN = """^$LOCAL_PART_PATTERN$ADDRESS_SEPARATOR$DOMAIN_PATTERN$"""
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity.kt
@@ -1,0 +1,15 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import walter.y.bookeye.web.domain.user.model.UserId
+
+class UserAccountEntity(
+    val userId: UserId,
+    val userAccountId: UserAccountId,
+    val principalName: PrincipalName,
+    val userAccountPassword: UserAccountPassword,
+    private val isEnabled: Boolean
+) {
+    fun isLocked(): Boolean = false
+
+    fun isEnabled(): Boolean = isEnabled
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId.kt
@@ -1,0 +1,26 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+class UserAccountId(
+    value: Long?
+) {
+    val value = kotlin.run {
+        requireNotNull(value) { "accountId should not be null" }
+        require(value in MIN..MAX) { "accountId should be $MIN to $MAX" }
+        value
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is UserAccountId) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    companion object {
+        private const val MIN = 1
+        private const val MAX = Long.MAX_VALUE
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword.kt
@@ -1,0 +1,100 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import org.springframework.security.crypto.password.PasswordEncoder
+class UserAccountPassword(
+    value: String?
+) {
+    private var value = kotlin.run {
+        requireNotNull(value) { "accountPassword should not be null" }
+        val trimmedValue = value.trim()
+        require(trimmedValue.isNotEmpty()) {
+            "accountPassword should not be empty"
+        }
+        require(trimmedValue.length == LENGTH) {
+            "accountPassword should be $LENGTH characters"
+        }
+        trimmedValue
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is UserAccountPassword) return false
+        return value == other.value
+    }
+
+    fun readOnce(): String {
+        check(value.isNotEmpty()) { "accountPassword is used twice" }
+        val readValue = value
+        value = ""
+        return readValue
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    companion object {
+        private const val LENGTH = 60
+    }
+
+    class Source(
+        value: String?
+    ) {
+        private var value = kotlin.run {
+            requireNotNull(value) { "accountPasswordSource should not be null" }
+            val trimmedValue = value.trim()
+            require(trimmedValue.isNotEmpty()) {
+                "accountPasswordSource should not be empty"
+            }
+            require(trimmedValue.length in MIN_LENGTH..MAX_LENGTH) {
+                "accountPasswordSource should be in $MIN_LENGTH to $MAX_LENGTH"
+            }
+            require(Regex(PATTERN).matches(trimmedValue)) {
+                "accountPasswordSource should match `$PATTERN`"
+            }
+            trimmedValue
+        }
+
+        override fun equals(other: Any?): Boolean {
+            if (other == null) return false
+            if (other !is Source) return false
+            return value == other.value
+        }
+
+        fun readOnce(): String {
+            check(value.isNotEmpty()) { "accountPasswordSource is used twice" }
+            val readValue = value
+            value = ""
+            return readValue
+        }
+
+        override fun hashCode(): Int {
+            return value.hashCode()
+        }
+
+        companion object {
+            private const val MIN_LENGTH = 8
+            private const val MAX_LENGTH = 64
+
+            /**
+             * パスワード要件
+             * - 英小文字1文字以上
+             * - 英大文字1文字以上
+             * - 数字1文字以上
+             * - 記号0文字以上
+             */
+            private const val PATTERN = """^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[a-zA-Z\d!@#$%^&*()\-_=+\[{\]};:'",<.>/?]*$"""
+        }
+    }
+
+    class Builder(
+        private val source: Source,
+        private val passwordEncoder: PasswordEncoder
+    ) {
+        fun build(): UserAccountPassword {
+            val rawPassword = source.readOnce()
+            val encodedPassword = passwordEncoder.encode(rawPassword)
+            return UserAccountPassword(encodedPassword)
+        }
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/repository/UserAccountRepository.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/account/repository/UserAccountRepository.kt
@@ -1,0 +1,8 @@
+﻿package walter.y.bookeye.web.domain.user.account.repository
+
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+
+interface UserAccountRepository {
+    fun getOrNull(principalName: PrincipalName): UserAccountEntity?
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/model/UserId.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/domain/user/model/UserId.kt
@@ -1,0 +1,26 @@
+﻿package walter.y.bookeye.web.domain.user.model
+
+class UserId(
+    value: Long?
+) {
+    val value = kotlin.run {
+        requireNotNull(value) { "userId should not be null" }
+        require(value in MIN..MAX) { "userId should be $MIN to $MAX" }
+        value
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (other == null) return false
+        if (other !is UserId) return false
+        return value == other.value
+    }
+
+    override fun hashCode(): Int {
+        return value.hashCode()
+    }
+
+    companion object {
+        private const val MIN = 1
+        private const val MAX = Long.MAX_VALUE
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal.kt
@@ -1,0 +1,29 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+data class UserPrincipal(
+    val userId: Long,
+    val accountId: Long,
+    val principalName: String,
+    private val password: String,
+    private val accountExpired: Boolean,
+    private val accountLocked: Boolean,
+    private val credentialExpired: Boolean,
+    private val accountEnabled: Boolean
+) : UserDetails {
+    override fun getAuthorities(): MutableCollection<out GrantedAuthority>? = mutableListOf()
+
+    override fun getPassword(): String = password
+
+    override fun getUsername(): String = principalName
+
+    override fun isAccountNonExpired(): Boolean = !accountExpired
+
+    override fun isAccountNonLocked(): Boolean = !accountLocked
+
+    override fun isCredentialsNonExpired(): Boolean = !credentialExpired
+
+    override fun isEnabled(): Boolean = accountEnabled
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal.kt
@@ -2,12 +2,16 @@
 
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+import walter.y.bookeye.web.domain.user.model.UserId
 
 data class UserPrincipal(
-    val userId: Long,
-    val accountId: Long,
-    val principalName: String,
-    private val password: String,
+    val userId: UserId,
+    val accountId: UserAccountId,
+    val principalName: PrincipalName,
+    private val password: UserAccountPassword,
     private val accountExpired: Boolean,
     private val accountLocked: Boolean,
     private val credentialExpired: Boolean,
@@ -15,9 +19,9 @@ data class UserPrincipal(
 ) : UserDetails {
     override fun getAuthorities(): MutableCollection<out GrantedAuthority>? = mutableListOf()
 
-    override fun getPassword(): String = password
+    override fun getPassword(): String = password.readOnce()
 
-    override fun getUsername(): String = principalName
+    override fun getUsername(): String = principalName.value
 
     override fun isAccountNonExpired(): Boolean = !accountExpired
 

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl.kt
@@ -1,22 +1,31 @@
 ﻿package walter.y.bookeye.web.interfaceAdapter.api.authentication.service
 
 import org.springframework.security.core.userdetails.UserDetailsService
-import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
 import walter.y.bookeye.web.interfaceAdapter.api.authentication.model.UserPrincipal
+import walter.y.bookeye.web.useCase.account.GetAccountUseCase
+import walter.y.bookeye.web.useCase.account.input.GetAccountInput
 
 @Service
 class UserDetailsServiceImpl(
-    private val passwordEncoder: PasswordEncoder
+    private val getAccountUseCase: GetAccountUseCase
 ) : UserDetailsService {
     override fun loadUserByUsername(username: String): UserPrincipal? {
+        val input = GetAccountInput(
+            principalName = PrincipalName(username)
+        )
+        val output = getAccountUseCase.execute(input)
+
+        if (output.account == null) return null
+
         return UserPrincipal(
-            userId = -1L,
-            accountId = -1L,
-            principalName = username,
-            password = passwordEncoder.encode("password"),
-            accountLocked = false,
-            accountEnabled = true,
+            userId = output.account.userId,
+            accountId = output.account.userAccountId,
+            principalName = output.account.principalName,
+            password = output.account.userAccountPassword,
+            accountLocked = output.account.isLocked(),
+            accountEnabled = output.account.isEnabled(),
             accountExpired = false,
             credentialExpired = false
         )

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl.kt
@@ -1,0 +1,24 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.authentication.service
+
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+import walter.y.bookeye.web.interfaceAdapter.api.authentication.model.UserPrincipal
+
+@Service
+class UserDetailsServiceImpl(
+    private val passwordEncoder: PasswordEncoder
+) : UserDetailsService {
+    override fun loadUserByUsername(username: String): UserPrincipal? {
+        return UserPrincipal(
+            userId = -1L,
+            accountId = -1L,
+            principalName = username,
+            password = passwordEncoder.encode("password"),
+            accountLocked = false,
+            accountEnabled = true,
+            accountExpired = false,
+            credentialExpired = false
+        )
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/PasswordConfig.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/PasswordConfig.kt
@@ -1,0 +1,11 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import walter.y.bookeye.web.domain.password.PasswordStrength
+
+@ConfigurationProperties(prefix = "app.api.password")
+class PasswordConfig(
+    bcryptStrength: Int
+) {
+    val bcryptStrength = PasswordStrength(bcryptStrength)
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/WebSecurityConfig.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/WebSecurityConfig.kt
@@ -4,7 +4,14 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import walter.y.bookeye.web.interfaceAdapter.api.handler.access.AccessDeniedHandlerImpl
+import walter.y.bookeye.web.interfaceAdapter.api.handler.authentication.AuthenticationEntryPointImpl
+import walter.y.bookeye.web.interfaceAdapter.api.handler.authentication.AuthenticationFailureHandlerImpl
+import walter.y.bookeye.web.interfaceAdapter.api.handler.authentication.AuthenticationSuccessHandlerImpl
+import walter.y.bookeye.web.interfaceAdapter.api.handler.logout.LogoutSuccessHandlerImpl
 
 @Configuration
 @EnableWebSecurity
@@ -13,11 +20,39 @@ open class WebSecurityConfig {
     open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http.authorizeHttpRequests { requests ->
             requests.requestMatchers(
-                "/api/system/**"
+                "/api/system/**",
+                "/api/login"
             )
                 .permitAll()
-                .anyRequest().authenticated()
+                .anyRequest()
+                .authenticated()
         }
+
+        http.formLogin { form ->
+            form.loginProcessingUrl("/api/login")
+                .usernameParameter("accountId")
+                .passwordParameter("password")
+                .successHandler(AuthenticationSuccessHandlerImpl())
+                .failureHandler(AuthenticationFailureHandlerImpl())
+        }
+
+        http.exceptionHandling { exception ->
+            exception.authenticationEntryPoint(AuthenticationEntryPointImpl())
+                .accessDeniedHandler(AccessDeniedHandlerImpl())
+        }
+
+        http.logout { logout ->
+            logout.logoutUrl("/api/logout")
+                .logoutSuccessHandler(LogoutSuccessHandlerImpl())
+        }
+
+        http.csrf { csrf ->
+            csrf.disable()
+        }
+
         return http.build()
     }
+
+    @Bean
+    open fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
 }

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/WebSecurityConfig.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/config/WebSecurityConfig.kt
@@ -15,7 +15,9 @@ import walter.y.bookeye.web.interfaceAdapter.api.handler.logout.LogoutSuccessHan
 
 @Configuration
 @EnableWebSecurity
-open class WebSecurityConfig {
+open class WebSecurityConfig(
+    private val passwordConfig: PasswordConfig
+) {
     @Bean
     open fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
         http.authorizeHttpRequests { requests ->
@@ -54,5 +56,5 @@ open class WebSecurityConfig {
     }
 
     @Bean
-    open fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder()
+    open fun passwordEncoder(): PasswordEncoder = BCryptPasswordEncoder(passwordConfig.bcryptStrength.value)
 }

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/access/AccessDeniedHandlerImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/access/AccessDeniedHandlerImpl.kt
@@ -1,0 +1,22 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.handler.access
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.apache.commons.logging.LogFactory
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.web.access.AccessDeniedHandler
+
+class AccessDeniedHandlerImpl : AccessDeniedHandler {
+    private val log = LogFactory.getLog(javaClass)
+    override fun handle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        accessDeniedException: AccessDeniedException
+    ) {
+        log.error("[handle]", accessDeniedException)
+        response.sendError(
+            HttpServletResponse.SC_FORBIDDEN,
+            "request is denied"
+        )
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationEntryPointImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationEntryPointImpl.kt
@@ -1,0 +1,22 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.handler.authentication
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.apache.commons.logging.LogFactory
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.AuthenticationEntryPoint
+
+class AuthenticationEntryPointImpl : AuthenticationEntryPoint {
+    private val log = LogFactory.getLog(javaClass)
+    override fun commence(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authException: AuthenticationException
+    ) {
+        log.error("[commence]", authException)
+        response.sendError(
+            HttpServletResponse.SC_UNAUTHORIZED,
+            "request is unauthorized"
+        )
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationFailureHandlerImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationFailureHandlerImpl.kt
@@ -1,0 +1,22 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.handler.authentication
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.apache.commons.logging.LogFactory
+import org.springframework.security.core.AuthenticationException
+import org.springframework.security.web.authentication.AuthenticationFailureHandler
+
+class AuthenticationFailureHandlerImpl : AuthenticationFailureHandler {
+    private val log = LogFactory.getLog(javaClass)
+    override fun onAuthenticationFailure(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        exception: AuthenticationException
+    ) {
+        log.error("[onAuthenticationFailure]", exception)
+        response.sendError(
+            HttpServletResponse.SC_UNAUTHORIZED,
+            "loginId / password is invalid"
+        )
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationSuccessHandlerImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/authentication/AuthenticationSuccessHandlerImpl.kt
@@ -1,0 +1,17 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.handler.authentication
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler
+
+class AuthenticationSuccessHandlerImpl : AuthenticationSuccessHandler {
+    override fun onAuthenticationSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+//        response.addCookie(Cookie("", ""))
+        response.status = HttpServletResponse.SC_OK
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/logout/LogoutSuccessHandlerImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/handler/logout/LogoutSuccessHandlerImpl.kt
@@ -1,0 +1,16 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.api.handler.logout
+
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.Authentication
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
+
+class LogoutSuccessHandlerImpl : LogoutSuccessHandler {
+    override fun onLogoutSuccess(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        authentication: Authentication
+    ) {
+        response.status = HttpServletResponse.SC_OK
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/path/system/controller/SystemControllerAdvice.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/api/path/system/controller/SystemControllerAdvice.kt
@@ -16,7 +16,7 @@ import walter.y.bookeye.web.interfaceAdapter.api.path.model.ApiErrorResDTO
 import walter.y.bookeye.web.useCase.system.AccessKeyValidateUseCase
 import walter.y.bookeye.web.useCase.system.input.AccessKeyValidateInput
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackageClasses = [SystemController::class])
 @Order(Ordered.HIGHEST_PRECEDENCE)
 class SystemControllerAdvice(
     private val accessKeyValidateUseCase: AccessKeyValidateUseCase

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/user/account/UserAccountRepositoryImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/user/account/UserAccountRepositoryImpl.kt
@@ -1,0 +1,32 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.repository.user.account
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Repository
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+import walter.y.bookeye.web.domain.user.account.repository.UserAccountRepository
+import walter.y.bookeye.web.domain.user.model.UserId
+
+@Repository
+class UserAccountRepositoryImpl(
+    private val passwordEncoder: PasswordEncoder
+) : UserAccountRepository {
+    override fun getOrNull(principalName: PrincipalName): UserAccountEntity? {
+        val userAccount = try {
+            UserAccountEntity(
+                userId = UserId(1L),
+                userAccountId = UserAccountId(1L),
+                principalName = principalName,
+                userAccountPassword = UserAccountPassword.Source("Account-Password-Used-4-Development-Only").let {
+                    UserAccountPassword.Builder(it, passwordEncoder).build()
+                },
+                isEnabled = true
+            )
+        } catch (ex: Exception) {
+            null
+        }
+        return userAccount
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCase.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCase.kt
@@ -1,0 +1,8 @@
+﻿package walter.y.bookeye.web.useCase.account
+
+import walter.y.bookeye.web.useCase.account.input.GetAccountInput
+import walter.y.bookeye.web.useCase.account.output.GetAccountOutput
+
+interface GetAccountUseCase {
+    fun execute(input: GetAccountInput): GetAccountOutput
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl.kt
@@ -1,32 +1,16 @@
 ﻿package walter.y.bookeye.web.useCase.account
 
-import org.springframework.security.crypto.password.PasswordEncoder
-import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
-import walter.y.bookeye.web.domain.user.account.model.UserAccountId
-import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
-import walter.y.bookeye.web.domain.user.model.UserId
+import walter.y.bookeye.web.domain.user.account.repository.UserAccountRepository
 import walter.y.bookeye.web.useCase.account.input.GetAccountInput
 import walter.y.bookeye.web.useCase.account.output.GetAccountOutput
 import walter.y.bookeye.web.useCase.annotation.UseCase
 
 @UseCase
 class GetAccountUseCaseImpl(
-    private val passwordEncoder: PasswordEncoder
+    private val userAccountRepository: UserAccountRepository
 ) : GetAccountUseCase {
     override fun execute(input: GetAccountInput): GetAccountOutput {
-        val userAccount = try {
-            UserAccountEntity(
-                userId = UserId(1L),
-                userAccountId = UserAccountId(1L),
-                principalName = input.principalName,
-                userAccountPassword = UserAccountPassword.Source("Account-Password-Used-4-Development-Only").let {
-                    UserAccountPassword.Builder(it, passwordEncoder).build()
-                },
-                isEnabled = true
-            )
-        } catch (ex: Exception) {
-            null
-        }
+        val userAccount = userAccountRepository.getOrNull(principalName = input.principalName)
         return GetAccountOutput(account = userAccount)
     }
 }

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl.kt
@@ -1,0 +1,32 @@
+﻿package walter.y.bookeye.web.useCase.account
+
+import org.springframework.security.crypto.password.PasswordEncoder
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+import walter.y.bookeye.web.domain.user.model.UserId
+import walter.y.bookeye.web.useCase.account.input.GetAccountInput
+import walter.y.bookeye.web.useCase.account.output.GetAccountOutput
+import walter.y.bookeye.web.useCase.annotation.UseCase
+
+@UseCase
+class GetAccountUseCaseImpl(
+    private val passwordEncoder: PasswordEncoder
+) : GetAccountUseCase {
+    override fun execute(input: GetAccountInput): GetAccountOutput {
+        val userAccount = try {
+            UserAccountEntity(
+                userId = UserId(1L),
+                userAccountId = UserAccountId(1L),
+                principalName = input.principalName,
+                userAccountPassword = UserAccountPassword.Source("Account-Password-Used-4-Development-Only").let {
+                    UserAccountPassword.Builder(it, passwordEncoder).build()
+                },
+                isEnabled = true
+            )
+        } catch (ex: Exception) {
+            null
+        }
+        return GetAccountOutput(account = userAccount)
+    }
+}

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/input/GetAccountInput.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/input/GetAccountInput.kt
@@ -1,0 +1,7 @@
+﻿package walter.y.bookeye.web.useCase.account.input
+
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+
+data class GetAccountInput(
+    val principalName: PrincipalName
+)

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/output/GetAccountOutput.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/useCase/account/output/GetAccountOutput.kt
@@ -1,0 +1,7 @@
+﻿package walter.y.bookeye.web.useCase.account.output
+
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+
+data class GetAccountOutput(
+    val account: UserAccountEntity?
+)

--- a/server/web/src/main/resources/application.yml
+++ b/server/web/src/main/resources/application.yml
@@ -4,7 +4,10 @@ logging:
     org.springframework: INFO
 
 app:
+  api:
+    password:
+      bcrypt-strength: ${PASSWORD_STRENGTH:10}
   gateway:
     env:
       system-setting:
-        access-key: ${SYSTEM_ACCESS_KEY:}
+        access-key: ${SYSTEM_ACCESS_KEY:System-Access-Key-Used-4-Development-Only}

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrengthTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrengthTest.kt
@@ -1,0 +1,101 @@
+﻿package walter.y.bookeye.web.domain.password
+
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [PasswordStrength] 初期状態
+ */
+class PasswordStrengthTest : BehaviorSpec({
+
+    Given("NULL") {
+        When("NULLの場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+    }
+
+    Given("数値") {
+        When("Int型最小値 の場合") {
+            val value = Int.MIN_VALUE
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+        When("-1 の場合") {
+            val value = -1
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+        When("0 の場合") {
+            val value = 0
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+        When("3 の場合") {
+            val value = 3
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+        When("4 の場合") {
+            val value = 4
+            Then("インスタンスの生成に成功すること") {
+                val act = shouldNotThrowAny {
+                    PasswordStrength(value)
+                }
+                act.value shouldBe value
+            }
+        }
+        When("10 の場合") {
+            val value = 10
+            Then("インスタンスの生成に成功すること") {
+                val act = shouldNotThrowAny {
+                    PasswordStrength(value)
+                }
+                act.value shouldBe value
+            }
+        }
+        When("31 の場合") {
+            val value = 31
+            Then("インスタンスの生成に成功すること") {
+                val act = shouldNotThrowAny {
+                    PasswordStrength(value)
+                }
+                act.value shouldBe value
+            }
+        }
+        When("32 の場合") {
+            val value = 32
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+        When("Int型最大値 の場合") {
+            val value = Int.MAX_VALUE
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PasswordStrength(value)
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength_equals.kt
@@ -1,0 +1,55 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.password
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * [PasswordStrength.equals]
+ */
+class PasswordStrength_equals : BehaviorSpec({
+    Given("other is NULL") {
+        val value = 10
+        val sut = PasswordStrength(value)
+        When("NULL を比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of PasswordStrength") {
+        val value = 10
+        val sut = PasswordStrength(value)
+        When("Int 型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+    Given("other is type of PasswordStrength") {
+        val value = 10
+        val sut = PasswordStrength(value)
+        When("同一の値を比較した場合") {
+            val other = PasswordStrength(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("異なる値を比較した場合") {
+            val otherValue = 12
+            val other = PasswordStrength(otherValue)
+            value shouldNotBe otherValue
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/password/PasswordStrength_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.password
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [PasswordStrength.hashCode]
+ */
+class PasswordStrength_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = 10
+        val sut = PasswordStrength(value)
+        When("hashCode を実行した場合") {
+            val act = sut.hashCode()
+            Then("value をハッシュ化した値と一致すること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalNameTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalNameTest.kt
@@ -1,0 +1,308 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [PrincipalName] 初期状態
+ */
+class PrincipalNameTest : BehaviorSpec({
+    Given("NULL") {
+        When("NULLの場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("トリミング") {
+        When("前後に空白が含まれない場合") {
+            val value = "principal.name1@example.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功して、valueの値が変わらないこと") {
+                act.value shouldBe value
+            }
+        }
+        When("前後に空白が含まれる場合") {
+            val value = "principal.name1@example.com"
+            val act = PrincipalName(" $value　")
+            Then("インスタンスの生成に成功して、valueの値がトリミングされていること") {
+                act.value shouldBe value
+            }
+        }
+        When("空白のみの場合") {
+            val value = "      　　　　"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("全体の文字長") {
+        When("7文字の場合") {
+            val value = "b@a.com"
+            value.length shouldBe 7
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("8文字の場合") {
+            val value = "cb@a.com"
+            value.length shouldBe 8
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("254文字の場合") {
+            val value = "b".repeat(60) + "@" + "a".repeat(189) + ".com"
+            value.length shouldBe 254
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("255文字の場合") {
+            val value = "b".repeat(60) + "@" + "a".repeat(190) + ".com"
+            value.length shouldBe 255
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("10000文字の場合") {
+            val value = "b".repeat(60) + "@" + "a".repeat(9935) + ".com"
+            value.length shouldBe 10000
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("@") {
+        When("@を含む場合") {
+            val value = "abcde@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("@を含まない場合") {
+            val value = "abcde.test.com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("local-part の長さ") {
+        When("0文字の場合") {
+            val value = "@test.com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("1文字の場合") {
+            val value = "b@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("64文字の場合") {
+            val value = "b".repeat(64) + "@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("65文字の場合") {
+            val value = "b".repeat(65) + "@test.com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("domain の長さ") {
+        When("0文字の場合") {
+            val value = "abcdefg@"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("1文字の場合") {
+            val value = "abcdefg@a"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("2文字の場合") {
+            val value = "abcdefg@ab"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("3文字の場合") {
+            val value = "abcdefg@a.b"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+    }
+
+    Given("local-part の文字種") {
+        When("半角英小文字のみの場合") {
+            val value = "abcdefghijklmnopqrstuvwxyz@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("半角英大文字のみの場合") {
+            val value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("半角数字のみの場合") {
+            val value = "0123456789@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("ドット以外の半角記号のみの場合") {
+            val value = "!#$%&'*+/=?^_`{|}~-@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("半角英字・半角数字・半角記号が混在する場合") {
+            val value = "abc-DEF_01234@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("ドットつなぎをする場合") {
+            val value = "abc-DEF.98765.4321@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("連続でドットを使った場合") {
+            val value = "abc-DEF..98765.4321@test.com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+    }
+
+    Given("domain の文字種") {
+        When("ドットなしの場合") {
+            val value = "abcdefgh@com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("ドットつなぎの場合") {
+            val value = "abcdefgh@test.com"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("ドットスタートの場合") {
+            val value = "abcdefgh@.com"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("ドット終わりの場合") {
+            val value = "abcdefgh@com."
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("半角数字の場合") {
+            val value = "abcdefgh@0123.456"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("半角英小文字の場合") {
+            val value = "abcdefgh@abc.efg"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("半角英大文字の場合") {
+            val value = "abcdefgh@ABC.EFG"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+        When("先頭がハイフンの場合") {
+            val value = "abcdefgh@-abc.efg"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("ドット区切りの単語の先頭がハイフンの場合") {
+            val value = "abcdefgh@abc.-efg"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    PrincipalName(value)
+                }
+            }
+        }
+        When("ドット区切りの単語の中間がハイフンの場合") {
+            val value = "abcdefgh@a-bc.e--fg"
+            val act = PrincipalName(value)
+            Then("インスタンスの生成に成功すること") {
+                act.value shouldBe value
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName_equals.kt
@@ -1,0 +1,55 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * [PrincipalName.equals]
+ */
+class PrincipalName_equals : BehaviorSpec({
+    Given("other is NULL") {
+        val sut = PrincipalName("principal.name1@example.com")
+        When("NULLを比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of PrincipalName") {
+        val value = "principal.name1@example.com"
+        val sut = PrincipalName(value)
+        When("String型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is type of PrincipalName") {
+        val value = "principal.name1@example.com"
+        val sut = PrincipalName(value)
+        When("同一の value を比較した場合") {
+            val other = PrincipalName(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("異なる value を比較した場合") {
+            val otherValue = "principal.name2@example.com"
+            val other = PrincipalName(otherValue)
+            val act = sut == other
+            Then("false が返ること") {
+                value shouldNotBe otherValue
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/PrincipalName_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [PrincipalName.hashCode]
+ */
+class PrincipalName_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = "principal.name1@example.com"
+        val sut = PrincipalName(value)
+        When("hashCodeを実行した場合") {
+            val act = sut.hashCode()
+            Then("value の値をhash化したものと同じであること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntityTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntityTest.kt
@@ -1,0 +1,35 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import walter.y.bookeye.web.domain.user.model.UserId
+
+/**
+ * [UserAccountEntity] 初期状態
+ */
+class UserAccountEntityTest : BehaviorSpec({
+    Given("正常系") {
+        val userId = UserId(1L)
+        val userAccountId = UserAccountId(1L)
+        val principalName = PrincipalName("principal.name1@test.com")
+        val accountPassword = UserAccountPassword.Builder(
+            source = UserAccountPassword.Source("Unit-Test-123"),
+            passwordEncoder = BCryptPasswordEncoder()
+        ).build()
+
+        When("インスタンス生成時") {
+            Then("エラーが発生しないこと") {
+                shouldNotThrow<Exception> {
+                    UserAccountEntity(
+                        userId = userId,
+                        userAccountId = userAccountId,
+                        principalName = principalName,
+                        userAccountPassword = accountPassword,
+                        isEnabled = true
+                    )
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity_isEnabled.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity_isEnabled.kt
@@ -1,0 +1,43 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserAccountEntity.isEnabled]
+ */
+class UserAccountEntity_isEnabled : BehaviorSpec({
+    Given("正常系") {
+        When("isEnabled を true で指定した場合") {
+            val isEnabled = true
+            val sut = UserAccountEntity(
+                userId = mockk(),
+                userAccountId = mockk(),
+                principalName = mockk(),
+                userAccountPassword = mockk(),
+                isEnabled = isEnabled
+            )
+            val act = sut.isEnabled()
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("isEnabled を false で指定した場合") {
+            val isEnabled = false
+            val sut = UserAccountEntity(
+                userId = mockk(),
+                userAccountId = mockk(),
+                principalName = mockk(),
+                userAccountPassword = mockk(),
+                isEnabled = isEnabled
+            )
+            val act = sut.isEnabled()
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity_isLocked.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountEntity_isLocked.kt
@@ -1,0 +1,43 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserAccountEntity.isLocked]
+ */
+class UserAccountEntity_isLocked : BehaviorSpec({
+    Given("正常系") {
+        When("isEnabled を true で指定した場合") {
+            val isEnabled = true
+            val sut = UserAccountEntity(
+                userId = mockk(),
+                userAccountId = mockk(),
+                principalName = mockk(),
+                userAccountPassword = mockk(),
+                isEnabled = isEnabled
+            )
+            val act = sut.isLocked()
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("isEnabled を false で指定した場合") {
+            val isEnabled = false
+            val sut = UserAccountEntity(
+                userId = mockk(),
+                userAccountId = mockk(),
+                principalName = mockk(),
+                userAccountPassword = mockk(),
+                isEnabled = isEnabled
+            )
+            val act = sut.isLocked()
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountIdTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountIdTest.kt
@@ -1,0 +1,72 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountId] 初期状態
+ */
+class UserAccountIdTest : BehaviorSpec({
+    Given("正常値") {
+        When("100の場合") {
+            val value = 100L
+            Then("インスタンスの生成に成功すること") {
+                val act = UserAccountId(value)
+                act.value shouldBe value
+            }
+        }
+    }
+
+    Given("NULL") {
+        When("NULLの場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountId(value)
+                }
+            }
+        }
+    }
+
+    Given("数値") {
+        When("${Long.MIN_VALUE}の場合") {
+            val value = Long.MIN_VALUE
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountId(value)
+                }
+            }
+        }
+        When("-1の場合") {
+            val value = -1L
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountId(value)
+                }
+            }
+        }
+        When("0の場合") {
+            val value = 0L
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountId(value)
+                }
+            }
+        }
+        When("1の場合") {
+            val value = 1L
+            Then("インスタンスの生成に成功すること") {
+                val act = UserAccountId(value)
+                act.value shouldBe value
+            }
+        }
+        When("${Long.MAX_VALUE}の場合") {
+            val value = Long.MAX_VALUE
+            Then("インスタンスの生成に成功すること") {
+                val act = UserAccountId(value)
+                act.value shouldBe value
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId_equals.kt
@@ -1,0 +1,60 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import walter.y.bookeye.web.domain.user.model.UserId
+
+/**
+ * [UserAccountId.equals]
+ */
+class UserAccountId_equals : BehaviorSpec({
+    Given("other is NULL") {
+        val sut = UserAccountId(1L)
+        When("NULLを比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of UserAccountId") {
+        val value = 1L
+        val sut = UserAccountId(value)
+        When("Long型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("UserId型を比較した場合") {
+            val other = UserId(value)
+            val act = sut.equals(other)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is type of UserAccountId") {
+        val value = 1L
+        val sut = UserAccountId(value)
+        When("同一のvalueを比較した場合") {
+            val other = UserAccountId(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("異なるvalueを比較した場合") {
+            val other = UserAccountId(value + 1)
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountId_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountId.hashCode]
+ */
+class UserAccountId_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = 1L
+        val sut = UserAccountId(value)
+        When("hashCodeを実行した場合") {
+            val act = sut.hashCode()
+            Then("value の値をhash化したものと同じであること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPasswordTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPasswordTest.kt
@@ -1,0 +1,75 @@
+﻿package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword] 初期状態
+ */
+class UserAccountPasswordTest : BehaviorSpec({
+    Given("NULL") {
+        When("NULLの場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword(value)
+                }
+            }
+        }
+    }
+
+    Given("トリミング") {
+        When("前後に空白を含まない場合") {
+            val value = "$2a$10$" + "a".repeat(53)
+            val act = UserAccountPassword(value)
+            Then("インスタンスの生成に成功して、値が変わらないこと") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("前後に空白を含む場合") {
+            val value = "$2a$10$" + "a".repeat(53)
+            val act = UserAccountPassword(" $value　")
+            Then("インスタンスの生成に成功して、値がトリミングされていること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("空白のみの場合") {
+            val value = " ".repeat(60)
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword(value)
+                }
+            }
+        }
+    }
+
+    Given("文字長") {
+        When("59文字の場合") {
+            val value = "$2a$10$" + "a".repeat(52)
+            value.length shouldBe 59
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword(value)
+                }
+            }
+        }
+        When("60文字の場合") {
+            val value = "$2a$10$" + "a".repeat(53)
+            value.length shouldBe 60
+            val act = UserAccountPassword(value)
+            Then("インスタンスの生成に成功して、値がトリミングされていること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("61文字の場合") {
+            val value = "$2a$10$" + "a".repeat(54)
+            value.length shouldBe 61
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword(value)
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Builder_build.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Builder_build.kt
@@ -1,0 +1,28 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+
+/**
+ * [UserAccountPassword.Builder.build]
+ */
+class UserAccountPassword_Builder_build : BehaviorSpec({
+    Given("正常系") {
+        val value = "Unit-Test-123"
+        val passwordSource = UserAccountPassword.Source(value)
+        val passwordEncoder = BCryptPasswordEncoder()
+        val sut = UserAccountPassword.Builder(
+            source = passwordSource,
+            passwordEncoder = passwordEncoder
+        )
+        When("buildを実行した場合") {
+            val act = sut.build()
+            Then("値がハッシュ化されていること") {
+                passwordEncoder.matches(value, act.readOnce()) shouldBe true
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_SourceTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_SourceTest.kt
@@ -1,0 +1,170 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword.Source] 初期状態
+ */
+class UserAccountPassword_SourceTest : BehaviorSpec({
+    Given("正常系") {
+        When("パスワードポリシーを満たす場合") {
+            val value = "Unit-Test-123"
+            val act = UserAccountPassword.Source(value)
+            Then("インスタンスの生成に成功すること") {
+                act.readOnce() shouldBe value
+            }
+        }
+    }
+
+    Given("NULL") {
+        When("NULL の場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+    }
+
+    Given("トリミング") {
+        When("前後に空白が含まれる場合") {
+            val value = "Unit-Test-123"
+            val act = UserAccountPassword.Source(" $value　")
+            Then("インスタンスの生成に成功して、valueの値がトリミングされていること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("空白のみの場合") {
+            val value = "      　　　　"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+    }
+
+    Given("文字長") {
+        When("7文字の場合") {
+            val value = "Unit123"
+            value.length shouldBe 7
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("8文字の場合") {
+            val value = "Unit1234"
+            value.length shouldBe 8
+            val act = UserAccountPassword.Source(value)
+            Then("インスタンスの生成に成功すること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("64文字の場合") {
+            val value = "Unit1234" + "a".repeat(56)
+            value.length shouldBe 64
+            val act = UserAccountPassword.Source(value)
+            Then("インスタンスの生成に成功すること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("65文字の場合") {
+            val value = "Unit1234" + "a".repeat(57)
+            value.length shouldBe 65
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("10000文字の場合") {
+            val value = "Unit1234" + "a".repeat(9992)
+            value.length shouldBe 10000
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+    }
+
+    Given("文字種") {
+        When("半角英小文字のみの場合") {
+            val value = "abcdefghijklmnopqrstuvwxyz"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("半角英大文字のみの場合") {
+            val value = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("半角数字のみの場合") {
+            val value = "0123456789"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("記号のみの場合") {
+            val value = """!@#$%^&*()-_=+[{]};:'",<.>/?"""
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("半角英小文字・半角英大文字・半角数字を1文字以上使用した場合") {
+            val value = "Abcdefg0123"
+            val act = UserAccountPassword.Source(value)
+            Then("インスタンスの生成に成功すること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("半角英小文字・半角英大文字・半角数字・記号を1文字以上使用した場合") {
+            val value = "Abcdefg0123-"
+            val act = UserAccountPassword.Source(value)
+            Then("インスタンスの生成に成功すること") {
+                act.readOnce() shouldBe value
+            }
+        }
+        When("半角英小文字・半角数字を1文字以上使用した場合") {
+            val value = "bcdefg0123"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("半角英大文字・半角数字を1文字以上使用した場合") {
+            val value = "ABCDEFG0123"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+        When("半角英小文字・半角英大文字を1文字以上使用した場合") {
+            val value = "abcdefgABCDEFG"
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserAccountPassword.Source(value)
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_equals.kt
@@ -1,0 +1,56 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * [UserAccountPassword.Source.equals]
+ */
+class UserAccountPassword_Source_equals : BehaviorSpec({
+    Given("other is NULL") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        When("NULL を比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of UserAccountPasswordSource") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        When("String 型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is type of UserAccountPasswordSource") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        When("同一の値をを比較した場合") {
+            val other = UserAccountPassword.Source(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("異なる値をを比較した場合") {
+            val otherValue = "Unit-Test-1234"
+            val other = UserAccountPassword.Source(otherValue)
+            value shouldNotBe otherValue
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword.Source.hashCode]
+ */
+class UserAccountPassword_Source_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        When("hashCode を実行した場合") {
+            val act = sut.hashCode()
+            Then("valueをhash化したものと一致すること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_readOnce.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_Source_readOnce.kt
@@ -1,0 +1,43 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword.Source.readOnce]
+ */
+class UserAccountPassword_Source_readOnce : BehaviorSpec({
+    Given("正常系") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        When("1回目の呼び出しの場合") {
+            val act = sut.readOnce()
+            Then("値を取得できること") {
+                act shouldBe value
+            }
+        }
+    }
+
+    Given("異常系") {
+        val value = "Unit-Test-123"
+        val sut = UserAccountPassword.Source(value)
+        sut.readOnce()
+        When("2回目の呼び出しの場合") {
+            Then("値の取得に失敗すること") {
+                shouldThrow<IllegalStateException> {
+                    sut.readOnce()
+                }
+            }
+        }
+        When("3回目の呼び出しの場合") {
+            Then("値の取得に失敗すること") {
+                shouldThrow<IllegalStateException> {
+                    sut.readOnce()
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_equals.kt
@@ -1,0 +1,60 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+/**
+ * [UserAccountPassword.equals]
+ */
+class UserAccountPassword_equals : BehaviorSpec({
+
+    Given("other is NULL") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+
+        When("NULL を比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of UserAccountPassword") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+        When("String 型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is type of UserAccountPassword") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+
+        When("同一の値を比較した場合") {
+            val other = UserAccountPassword(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+
+        When("異なる値を比較した場合") {
+            val otherValue = "$2a$10$" + "b".repeat(53)
+            val other = UserAccountPassword(otherValue)
+            value shouldNotBe otherValue
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword.hashCode]
+ */
+class UserAccountPassword_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+        When("hashCode を実行した場合") {
+            val act = sut.hashCode()
+            Then("value をhash化した値と一致すること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_readOnce.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/account/model/UserAccountPassword_readOnce.kt
@@ -1,0 +1,43 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.account.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserAccountPassword.readOnce]
+ */
+class UserAccountPassword_readOnce : BehaviorSpec({
+    Given("正常系") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+        When("1回目の呼び出しの場合") {
+            val act = sut.readOnce()
+            Then("値が取得できること") {
+                act shouldBe value
+            }
+        }
+    }
+
+    Given("複数呼び出し") {
+        val value = "$2a$10$" + "a".repeat(53)
+        val sut = UserAccountPassword(value)
+        sut.readOnce()
+        When("2回目の呼び出しの場合") {
+            Then("値の取得に失敗すること") {
+                shouldThrow<IllegalStateException> {
+                    sut.readOnce()
+                }
+            }
+        }
+        When("3回目の呼び出しの場合") {
+            Then("値の取得に失敗すること") {
+                shouldThrow<IllegalStateException> {
+                    sut.readOnce()
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserIdTest.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserIdTest.kt
@@ -1,0 +1,72 @@
+﻿package walter.y.bookeye.web.domain.user.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserId] 初期状態
+ */
+class UserIdTest : BehaviorSpec({
+    Given("正常値") {
+        When("100の場合") {
+            val value = 100L
+            Then("インスタンスの生成に成功すること") {
+                val act = UserId(value)
+                act.value shouldBe value
+            }
+        }
+    }
+
+    Given("NULL") {
+        When("NULLの場合") {
+            val value = null
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserId(value)
+                }
+            }
+        }
+    }
+
+    Given("数値") {
+        When("${Long.MIN_VALUE}の場合") {
+            val value = Long.MIN_VALUE
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserId(value)
+                }
+            }
+        }
+        When("-1の場合") {
+            val value = -1L
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserId(value)
+                }
+            }
+        }
+        When("0の場合") {
+            val value = 0L
+            Then("インスタンスの生成に失敗すること") {
+                shouldThrow<IllegalArgumentException> {
+                    UserId(value)
+                }
+            }
+        }
+        When("1の場合") {
+            val value = 1L
+            Then("インスタンスの生成に成功すること") {
+                val act = UserId(value)
+                act.value shouldBe value
+            }
+        }
+        When("${Long.MAX_VALUE}の場合") {
+            val value = Long.MAX_VALUE
+            Then("インスタンスの生成に成功すること") {
+                val act = UserId(value)
+                act.value shouldBe value
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserId_equals.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserId_equals.kt
@@ -1,0 +1,60 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+
+/**
+ * [UserId.equals]
+ */
+class UserId_equals : BehaviorSpec({
+    Given("other is NULL") {
+        val sut = UserId(1L)
+        When("NULLを比較した場合") {
+            val other = null
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is not type of UserId") {
+        val value = 1L
+        val sut = UserId(value)
+        When("Long型を比較した場合") {
+            val act = sut.equals(value)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("UserAccountId型を比較した場合") {
+            val other = UserAccountId(value)
+            val act = sut.equals(other)
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+
+    Given("other is type of UserId") {
+        val value = 1L
+        val sut = UserId(value)
+        When("同一のvalueを比較した場合") {
+            val other = UserId(value)
+            val act = sut == other
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("異なるvalueを比較した場合") {
+            val other = UserId(value + 1)
+            val act = sut == other
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserId_hashCode.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/domain/user/model/UserId_hashCode.kt
@@ -1,0 +1,22 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.domain.user.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * [UserId.hashCode]
+ */
+class UserId_hashCode : BehaviorSpec({
+    Given("正常系") {
+        val value = 1L
+        val sut = UserId(value)
+        When("hashCodeを実行した場合") {
+            val act = sut.hashCode()
+            Then("value の値をhash化したものと同じであること") {
+                act shouldBe value.hashCode()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getAuthorities.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getAuthorities.kt
@@ -1,0 +1,31 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserPrincipal.getAuthorities]
+ */
+class UserPrincipal_getAuthorities : BehaviorSpec({
+    Given("正常系") {
+        val sut = UserPrincipal(
+            userId = mockk(),
+            accountId = mockk(),
+            principalName = mockk(relaxed = true),
+            password = mockk(relaxed = true),
+            accountExpired = mockk(relaxed = true),
+            accountLocked = mockk(relaxed = true),
+            accountEnabled = mockk(relaxed = true),
+            credentialExpired = mockk(relaxed = true)
+        )
+        When("メソッドを実行した場合") {
+            val act = sut.authorities
+            Then("空のMutableCollectionが返ること") {
+                act shouldBe mutableListOf()
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getPassword.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getPassword.kt
@@ -1,0 +1,56 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+
+/**
+ * [UserPrincipal.getPassword]
+ */
+class UserPrincipal_getPassword : BehaviorSpec({
+    Given("正常系") {
+        val password = "$2a$10$" + "a".repeat(53)
+        val sut = UserPrincipal(
+            userId = mockk(),
+            accountId = mockk(),
+            principalName = mockk(relaxed = true),
+            password = UserAccountPassword(password),
+            accountExpired = mockk(relaxed = true),
+            accountLocked = mockk(relaxed = true),
+            accountEnabled = mockk(relaxed = true),
+            credentialExpired = mockk(relaxed = true)
+        )
+        When("1回目にメソッドを実行した場合") {
+            val act = sut.password
+            Then("パスワードを取得できること") {
+                act shouldBe password
+            }
+        }
+    }
+
+    Given("異常系") {
+        val password = "$2a$10$" + "a".repeat(53)
+        val sut = UserPrincipal(
+            userId = mockk(),
+            accountId = mockk(),
+            principalName = mockk(relaxed = true),
+            password = UserAccountPassword(password),
+            accountExpired = mockk(relaxed = true),
+            accountLocked = mockk(relaxed = true),
+            accountEnabled = mockk(relaxed = true),
+            credentialExpired = mockk(relaxed = true)
+        )
+        sut.password
+        When("複数回メソッドを実行した場合") {
+            Then("IllegalStateException が発生すること") {
+                shouldThrow<IllegalStateException> {
+                    sut.password
+                }
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getUsername.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_getUsername.kt
@@ -1,0 +1,33 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+
+/**
+ * [UserPrincipal.getUsername]
+ */
+class UserPrincipal_getUsername : BehaviorSpec({
+    Given("正常系") {
+        val principalName = PrincipalName("principal.name1@test.com")
+        val sut = UserPrincipal(
+            userId = mockk(),
+            accountId = mockk(),
+            principalName = principalName,
+            password = mockk(relaxed = true),
+            accountExpired = mockk(relaxed = true),
+            accountLocked = mockk(relaxed = true),
+            accountEnabled = mockk(relaxed = true),
+            credentialExpired = mockk(relaxed = true)
+        )
+        When("メソッドを実行した場合") {
+            val act = sut.username
+            Then("PrincipalNameの値が返ってくること") {
+                act shouldBe principalName.value
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isAccountNonExpired.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isAccountNonExpired.kt
@@ -1,0 +1,47 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserPrincipal.isAccountNonExpired]
+ */
+class UserPrincipal_isAccountNonExpired : BehaviorSpec({
+    Given("正常系") {
+        When("accountExpired が true の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = true,
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isAccountNonExpired
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("accountExpired が false の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = false,
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isAccountNonExpired
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isAccountNonLocked.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isAccountNonLocked.kt
@@ -1,0 +1,47 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserPrincipal.isAccountNonLocked]
+ */
+class UserPrincipal_isAccountNonLocked : BehaviorSpec({
+    Given("正常系") {
+        When("accountLocked が true の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = true,
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isAccountNonLocked
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("accountLocked が false の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = false,
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isAccountNonLocked
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isCredentialsNonExpired.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isCredentialsNonExpired.kt
@@ -1,0 +1,47 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserPrincipal.isCredentialsNonExpired]
+ */
+class UserPrincipal_isCredentialsNonExpired : BehaviorSpec({
+    Given("正常系") {
+        When("credentialExpired が true の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = true
+            )
+            val act = sut.isCredentialsNonExpired
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+        When("credentialExpired が false の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = mockk(relaxed = true),
+                credentialExpired = false
+            )
+            val act = sut.isAccountNonLocked
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isEnabled.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/model/UserPrincipal_isEnabled.kt
@@ -1,0 +1,47 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.model
+
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+
+/**
+ * [UserPrincipal.isEnabled]
+ */
+class UserPrincipal_isEnabled : BehaviorSpec({
+    Given("正常系") {
+        When("accountEnabled が true の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = true,
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isEnabled
+            Then("true が返ること") {
+                act shouldBe true
+            }
+        }
+        When("accountEnabled が false の場合") {
+            val sut = UserPrincipal(
+                userId = mockk(),
+                accountId = mockk(),
+                principalName = mockk(relaxed = true),
+                password = mockk(relaxed = true),
+                accountExpired = mockk(relaxed = true),
+                accountLocked = mockk(relaxed = true),
+                accountEnabled = false,
+                credentialExpired = mockk(relaxed = true)
+            )
+            val act = sut.isEnabled
+            Then("false が返ること") {
+                act shouldBe false
+            }
+        }
+    }
+})

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl_loadByUsername.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/interfaceAdapter/api/authentication/service/UserDetailsServiceImpl_loadByUsername.kt
@@ -1,0 +1,124 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.interfaceAdapter.api.authentication.service
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+import walter.y.bookeye.web.domain.user.model.UserId
+import walter.y.bookeye.web.interfaceAdapter.api.authentication.model.UserPrincipal
+import walter.y.bookeye.web.useCase.account.GetAccountUseCase
+import walter.y.bookeye.web.useCase.account.input.GetAccountInput
+import walter.y.bookeye.web.useCase.account.output.GetAccountOutput
+
+/**
+ * [UserDetailsServiceImpl.loadUserByUsername]
+ */
+class UserDetailsServiceImpl_loadByUsername : BehaviorSpec({
+    Given("正常系") {
+        val mockGetAccountUseCase = mockk<GetAccountUseCase>()
+        val sut = UserDetailsServiceImpl(getAccountUseCase = mockGetAccountUseCase)
+        val username = "principal.name1@test.com"
+
+        When("GetAccountUseCase.execute でアカウントを取得できた場合") {
+            val userAccount = UserAccountEntity(
+                userId = UserId(1L),
+                userAccountId = UserAccountId(1L),
+                principalName = PrincipalName(username),
+                userAccountPassword = UserAccountPassword("$2a$10$" + "a".repeat(53)),
+                isEnabled = true
+            )
+            every {
+                mockGetAccountUseCase.execute(any())
+            } returns GetAccountOutput(account = userAccount)
+
+            val act = sut.loadUserByUsername(username = username)
+
+            Then("UserPrincipal が返ること") {
+                act shouldBe UserPrincipal(
+                    userId = userAccount.userId,
+                    accountId = userAccount.userAccountId,
+                    principalName = userAccount.principalName,
+                    password = userAccount.userAccountPassword,
+                    accountExpired = false,
+                    accountLocked = userAccount.isLocked(),
+                    accountEnabled = userAccount.isEnabled(),
+                    credentialExpired = false
+                )
+                verify(exactly = 1) {
+                    mockGetAccountUseCase.execute(GetAccountInput(principalName = PrincipalName(username)))
+                }
+            }
+        }
+        When("GetAccountUseCase.execute でアカウントを取得できなかった場合") {
+            every {
+                mockGetAccountUseCase.execute(any())
+            } returns GetAccountOutput(account = null)
+
+            val act = sut.loadUserByUsername(username = username)
+
+            Then("NULL が返ること") {
+                act shouldBe null
+                verify(exactly = 1) {
+                    mockGetAccountUseCase.execute(GetAccountInput(principalName = PrincipalName(username)))
+                }
+            }
+        }
+    }
+
+    Given("異常系") {
+        val mockGetAccountUseCase = mockk<GetAccountUseCase>()
+        val sut = UserDetailsServiceImpl(getAccountUseCase = mockGetAccountUseCase)
+        val username = "principal.name1@test.com"
+
+        When("GetAccountUseCase.execute で IllegalArgumentException が発生した場合") {
+            val message = "illegal argument"
+            every {
+                mockGetAccountUseCase.execute(any())
+            } throws IllegalArgumentException(message)
+
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<IllegalArgumentException> {
+                    sut.loadUserByUsername(username)
+                }
+                act.message shouldBe message
+            }
+        }
+        When("GetAccountUseCase.execute で IllegalStateException が発生した場合") {
+            val message = "illegal state"
+            every {
+                mockGetAccountUseCase.execute(any())
+            } throws IllegalStateException(message)
+
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<IllegalStateException> {
+                    sut.loadUserByUsername(username)
+                }
+                act.message shouldBe message
+            }
+        }
+        When("GetAccountUseCase.execute で Exception が発生した場合") {
+            val message = "exception"
+            every {
+                mockGetAccountUseCase.execute(any())
+            } throws Exception(message)
+
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<Exception> {
+                    sut.loadUserByUsername(username)
+                }
+                act.message shouldBe message
+            }
+        }
+    }
+}) {
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerTest
+}

--- a/server/web/src/test/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl_execute.kt
+++ b/server/web/src/test/kotlin/walter/y/bookeye/web/useCase/account/GetAccountUseCaseImpl_execute.kt
@@ -1,0 +1,108 @@
+﻿@file:Suppress("ClassName")
+
+package walter.y.bookeye.web.useCase.account
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import walter.y.bookeye.web.domain.user.account.model.PrincipalName
+import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
+import walter.y.bookeye.web.domain.user.account.model.UserAccountId
+import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
+import walter.y.bookeye.web.domain.user.account.repository.UserAccountRepository
+import walter.y.bookeye.web.domain.user.model.UserId
+import walter.y.bookeye.web.useCase.account.input.GetAccountInput
+import walter.y.bookeye.web.useCase.account.output.GetAccountOutput
+
+/**
+ * [GetAccountUseCaseImpl.execute]
+ */
+class GetAccountUseCaseImpl_execute : BehaviorSpec({
+    Given("正常系") {
+        val mockUserAccountRepository = mockk<UserAccountRepository>()
+        val sut = GetAccountUseCaseImpl(userAccountRepository = mockUserAccountRepository)
+        When("UserAccountRepository.getOrNull で1件取得した場合") {
+            val principalName = PrincipalName("principal.name@test.com")
+            val userAccount = UserAccountEntity(
+                userId = UserId(1L),
+                userAccountId = UserAccountId(1L),
+                principalName = principalName,
+                userAccountPassword = UserAccountPassword("$2a$10$" + "a".repeat(53)),
+                isEnabled = true
+            )
+            every {
+                mockUserAccountRepository.getOrNull(any())
+            } returns userAccount
+
+            val act = sut.execute(GetAccountInput(principalName = principalName))
+            Then("userAccountの情報を返すこと") {
+                act shouldBe GetAccountOutput(account = userAccount)
+                verify(exactly = 1) {
+                    mockUserAccountRepository.getOrNull(principalName)
+                }
+            }
+        }
+        When("UserAccountRepository.getOrNull で NULL を受け取った場合") {
+            val principalName = PrincipalName("principal.name@test.com")
+            every {
+                mockUserAccountRepository.getOrNull(any())
+            } returns null
+
+            val act = sut.execute(GetAccountInput(principalName = principalName))
+            Then("userAccountを NULL で返すこと") {
+                act shouldBe GetAccountOutput(account = null)
+                verify(exactly = 1) {
+                    mockUserAccountRepository.getOrNull(principalName)
+                }
+            }
+        }
+    }
+
+    Given("異常系") {
+        val mockUserAccountRepository = mockk<UserAccountRepository>()
+        val sut = GetAccountUseCaseImpl(userAccountRepository = mockUserAccountRepository)
+        val principalName = PrincipalName("principal.name1@test.com")
+        When("UserAccountRepository.getOrNull で IllegalArgumentException が発生した場合") {
+            val message = "Illegal argument"
+            every {
+                mockUserAccountRepository.getOrNull(any())
+            } throws IllegalArgumentException(message)
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<IllegalArgumentException> {
+                    sut.execute(GetAccountInput(principalName = principalName))
+                }
+                act.message shouldBe message
+            }
+        }
+        When("UserAccountRepository.getOrNull で IllegalStateException が発生した場合") {
+            val message = "Illegal state"
+            every {
+                mockUserAccountRepository.getOrNull(any())
+            } throws IllegalStateException(message)
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<IllegalStateException> {
+                    sut.execute(GetAccountInput(principalName = principalName))
+                }
+                act.message shouldBe message
+            }
+        }
+        When("UserAccountRepository.getOrNull で Exception が発生した場合") {
+            val message = "exception"
+            every {
+                mockUserAccountRepository.getOrNull(any())
+            } throws Exception(message)
+            Then("例外がそのまま返ること") {
+                val act = shouldThrow<Exception> {
+                    sut.execute(GetAccountInput(principalName = principalName))
+                }
+                act.message shouldBe message
+            }
+        }
+    }
+}) {
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerTest
+}


### PR DESCRIPTION
## 概要
- ログイン機能の実装（Repositoryのつなぎこみまで）

## 変更内容
- WebSecurityConfig にログイン設定を追加
- UserDetailsServiceImpl にユーザアカウント取得処理を実装
- UserPrincipal にログイン中の保持情報を記載
- GetUserAccountUseCaseImpl にログインアカウント取得処理を実装
- UserAccountRepositoryImpl に固定のパスワードでユーザアカウント情報を返す仮のふるまいを実装

## 懸念事項
- テストコードも同時に実装するとファイル差分が多くなるため、ほどよいブランチ分割方法を検討したい

## やらないこと
- DBのつなぎこみ
- DockerのDB設定
