### PR TITLE
book_eye データベースをDockerで作成するようにする

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -42,5 +42,3 @@ out/
 
 ### Docker ###
 book-eye-infra/mysql/volumes/data
-
-

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -41,5 +41,6 @@ out/
 .env.**
 
 ### Docker ###
-/docker/book-eye-infra/mysql/volumes/data
-/docker/book-eye-infra/mysql/volumes/my.cnf
+book-eye-infra/mysql/volumes/data
+
+

--- a/server/README.md
+++ b/server/README.md
@@ -1,7 +1,8 @@
 # book-eye/server
 書籍管理システムのサーバーサイド
 - [web](web/README.md)
-- [docker](docker/README.md)
+- [book-eye-infra](book-eye-infra/README.md)
+- [book-eye-test-infra](book-eye-test-infra/README.md)
 
 ## 動作環境
 - Spring Boot 3.x

--- a/server/book-eye-infra/README.md
+++ b/server/book-eye-infra/README.md
@@ -1,0 +1,2 @@
+# book-eye/server/book-eye-infra
+開発用Docker

--- a/server/book-eye-infra/build.gradle.kts
+++ b/server/book-eye-infra/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins {
+    alias(libs.plugins.docker.compose)
+}

--- a/server/book-eye-infra/docker-compose.yml
+++ b/server/book-eye-infra/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  database:
+    image: mysql:8.0.33
+    container_name: book-eye-mysql
+    restart: always
+    environment:
+      TZ: Asia/Tokyo
+      MYSQL_DATABASE: book_eye
+      MYSQL_ROOT_PASSWORD: test
+    volumes:
+      - ./mysql/volumes/data:/var/lib/mysql
+      - ./mysql/volumes/my.cnf:/etc/mysql/conf.d/my.cnf
+      - ../sql:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:3306

--- a/server/book-eye-infra/mysql/volumes/my.cnf
+++ b/server/book-eye-infra/mysql/volumes/my.cnf
@@ -1,0 +1,6 @@
+﻿[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[client]
+default-character-set=utf8mb4

--- a/server/book-eye-test-infra/README.md
+++ b/server/book-eye-test-infra/README.md
@@ -1,0 +1,2 @@
+﻿# book-eye/server/book-eye-test-infra
+テスト実行用Docker

--- a/server/book-eye-test-infra/build.gradle.kts
+++ b/server/book-eye-test-infra/build.gradle.kts
@@ -1,0 +1,3 @@
+﻿plugins {
+    alias(libs.plugins.docker.compose)
+}

--- a/server/book-eye-test-infra/docker-compose.yml
+++ b/server/book-eye-test-infra/docker-compose.yml
@@ -3,13 +3,12 @@ services:
     image: mysql:8.0.33
     container_name: book-eye-mysql
     restart: always
-    env_file:
-      - .env.docker
     environment:
       TZ: Asia/Tokyo
+      MYSQL_DATABASE: book_eye
+      MYSQL_ROOT_PASSWORD: test
     volumes:
-      - ./mysql/volumes/data:/var/lib/mysql
       - ./mysql/volumes/my.cnf:/etc/mysql/conf.d/my.cnf
-      - ./mysql/volumes/sql:/docker-entrypoint-initdb.d
+      - ../sql:/docker-entrypoint-initdb.d
     ports:
-      - 3306:3306
+      - 63306:3306

--- a/server/book-eye-test-infra/mysql/volumes/my.cnf
+++ b/server/book-eye-test-infra/mysql/volumes/my.cnf
@@ -1,0 +1,6 @@
+﻿[mysqld]
+character-set-server=utf8mb4
+collation-server=utf8mb4_unicode_ci
+
+[client]
+default-character-set=utf8mb4

--- a/server/docker/README.md
+++ b/server/docker/README.md
@@ -1,2 +1,0 @@
-# book-eye/server/docker
-開発用Docker

--- a/server/docker/build.gradle.kts
+++ b/server/docker/build.gradle.kts
@@ -1,7 +1,0 @@
-plugins {
-    alias(libs.plugins.docker.compose)
-}
-
-dockerCompose {
-    setDockerComposeFile(project.file("book-eye-infra/docker-compose.yml"))
-}

--- a/server/settings.gradle.kts
+++ b/server/settings.gradle.kts
@@ -1,4 +1,5 @@
 include(
     "web",
-    "docker",
+    "book-eye-infra",
+    "book-eye-test-infra",
 )

--- a/server/sql/0_0_0.sql
+++ b/server/sql/0_0_0.sql
@@ -1,0 +1,13 @@
+﻿CREATE TABLE IF NOT EXISTS sql_version(
+  sql_version_id BIGINT AUTO_INCREMENT NOT NULL COMMENT 'ID',
+  version_label VARCHAR(10) NOT NULL COMMENT 'バージョン',
+  version_comment VARCHAR(255) NOT NULL COMMENT 'バージョンコメント',
+
+  created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) COMMENT '作成日時',
+  updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新日時',
+
+  CONSTRAINT sql_version_PK PRIMARY KEY(sql_version_id)
+
+) COMMENT 'SQLのバージョン管理';
+
+INSERT INTO sql_version(version_label, version_comment) VALUES('0_0_0', 'sql_version テーブルの作成');

--- a/server/sql/1_0_0.sql
+++ b/server/sql/1_0_0.sql
@@ -1,0 +1,28 @@
+﻿CREATE TABLE IF NOT EXISTS user(
+  user_id BIGINT AUTO_INCREMENT NOT NULL COMMENT 'ID',
+  user_name VARCHAR(50) NOT NULL COMMENT 'ユーザ表示名',
+
+  created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) COMMENT '作成日時',
+  updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新日時',
+
+  CONSTRAINT user_PK PRIMARY KEY(user_id)
+
+) COMMENT 'ユーザ情報';
+
+CREATE TABLE IF NOT EXISTS user_account(
+  user_account_id BIGINT AUTO_INCREMENT NOT NULL COMMENT 'ID',
+  principal_name VARCHAR(254) NOT NULL COMMENT 'ログインアカウント名',
+  account_password VARCHAR(60) NOT NULL COMMENT 'パスワード',
+  is_enabled BOOLEAN NOT NULL DEFAULT FALSE COMMENT 'アカウント有効',
+  user_id BIGINT NOT NULL COMMENT 'ユーザID',
+
+  created_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) COMMENT '作成日時',
+  updated_at DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) COMMENT '更新日時',
+
+  CONSTRAINT user_account_PK PRIMARY KEY(user_account_id),
+  CONSTRAINT user_account_UK_principal_name UNIQUE KEY(principal_name),
+  CONSTRAINT user_account_FK_user_id FOREIGN KEY(user_id) REFERENCES user(user_id) ON UPDATE NO ACTION ON DELETE NO ACTION
+
+) COMMENT 'ユーザアカウント情報';
+
+INSERT INTO sql_version(version_label, version_comment) VALUES('1_0_0', 'user, user_account のテーブル追加');


### PR DESCRIPTION
## 概要
- 表題通り
## 変更内容
- 開発用のDockerコンテナのMYSQLの初期化
- テスト用のDockerコンテナのMYSQLの初期化

## やらないこと
- アプリ、テストにMYSQLを接続する
