### PR TITLE
Spring JDBC を追加する

### DIFF
--- a/.github/workflows/server-lint.yml
+++ b/.github/workflows/server-lint.yml
@@ -1,3 +1,5 @@
+name: Lint Server
+
 on:
   workflow_dispatch:
   push:

--- a/.github/workflows/server-test.yml
+++ b/.github/workflows/server-test.yml
@@ -1,3 +1,5 @@
+name: Test Server
+
 on:
   workflow_dispatch:
   push:
@@ -23,8 +25,14 @@ jobs:
       - name: Grant Excecte Permission for Gradle
         run: chmod +x gradlew
 
+      - name: Setup Docker
+        run: ./gradlew book-eye-test-infra:dockerComposeUp
+      
       - name: Execute Test
         run: ./gradlew test
 
       - name: Execute Integration Test
         run: ./gradlew integrationTest
+
+      - name: Finalize Docker
+        run: ./gradlew book-eye-test-infra:dockerComposeDown

--- a/server/book-eye-test-infra/docker-compose.yml
+++ b/server/book-eye-test-infra/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   database:
     image: mysql:8.0.33
-    container_name: book-eye-mysql
+    container_name: book-eye-test-mysql
     restart: always
     environment:
       TZ: Asia/Tokyo

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -32,12 +32,12 @@ subprojects {
 		}
 	}
 
-	tasks.withType<JavaExec>().configureEach {
-		javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
-	}
-
 	dependencies {
 		implementation("org.jetbrains.kotlin:kotlin-reflect")
+	}
+
+	tasks.withType<JavaExec>().configureEach {
+		javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
 	}
 
 	tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -32,13 +32,12 @@ subprojects {
 		}
 	}
 
-	dependencies {
-		implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
-		implementation("org.jetbrains.kotlin:kotlin-reflect")
-	}
-
 	tasks.withType<JavaExec>().configureEach {
 		javaLauncher.set(javaToolchains.launcherFor(java.toolchain))
+	}
+
+	dependencies {
+		implementation("org.jetbrains.kotlin:kotlin-reflect")
 	}
 
 	tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -14,12 +14,12 @@ mockk = { group = "io.mockk", name = "mockk", version = "1.13.5" }
 mysql-connector-j = { group = "com.mysql", name = "mysql-connector-j", version.ref = "mysql" }
 jackson-core = { group = "com.fasterxml.jackson.core", name = "jackson-core", version.ref = "jackson" }
 jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jackson" }
-jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version = "jackson" }
+jackson-module-kotlin = { group = "com.fasterxml.jackson.module", name = "jackson-module-kotlin", version.ref = "jackson" }
 
 [bundles]
 test = ["archunit", "kotest-assertions-core", "kotest-runner-jnunit5", "mockk"]
 integrationTest = ["kotest-assertions-core", "kotest-runner-jnunit5", "kotest-extensions-spring"]
-jackson = ["jackson-core", "jackson-databind"]
+jackson = ["jackson-core", "jackson-databind", "jackson-module-kotlin"]
 
 [plugins]
 docker-compose = { id = "com.palantir.docker-compose", version = "0.35.0" }
@@ -27,5 +27,5 @@ kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-spring = { id = "org.jetbrains.kotlin.plugin.spring", version.ref = "kotlin" }
 ktlint-idea = { id = "org.jlleitschuh.gradle.ktlint-idea", version.ref = "ktlint" }
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-spring-boot = { id = "org.springframework.boot", version = "3.1.0" }
+spring-boot = { id = "org.springframework.boot", version = "3.1.1" }
 spring-dependencies-management = { id = "io.spring.dependency-management", version = "1.1.0" }

--- a/server/web/build.gradle.kts
+++ b/server/web/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 dependencies {
+    project(":book-eye-test-infra")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")

--- a/server/web/build.gradle.kts
+++ b/server/web/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
+    implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.core:jackson-core")
     implementation("com.fasterxml.jackson.core:jackson-databind")
     runtimeOnly("com.mysql:mysql-connector-j")

--- a/server/web/build.gradle.kts
+++ b/server/web/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
 }
 
 dependencies {
-    project(":book-eye-test-infra")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")

--- a/server/web/src/integrationTest/resources/application.yml
+++ b/server/web/src/integrationTest/resources/application.yml
@@ -1,3 +1,10 @@
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:63306/book_eye
+    username: root
+    password: test
+
 app:
   api:
     password:

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/annotation/Repository.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/annotation/Repository.kt
@@ -1,0 +1,16 @@
+﻿package walter.y.bookeye.web.interfaceAdapter.repository.annotation
+
+import org.springframework.core.annotation.AliasFor
+import org.springframework.stereotype.Component
+
+/**
+ * [org.springframework.stereotype.Repository] の代用
+ * - Spring JDBC を使用する場合、`@Repository` を付与した class が、database にアクセスすることを強制されるため
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Component
+annotation class Repository(
+    @get:AliasFor(annotation = Component::class) val value: String = ""
+)

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/system/setting/SystemSettingRepositoryImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/system/setting/SystemSettingRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package walter.y.bookeye.web.interfaceAdapter.repository.system.setting
 
-import org.springframework.stereotype.Repository
 import walter.y.bookeye.web.domain.system.setting.model.SystemSettingEntity
 import walter.y.bookeye.web.domain.system.setting.repository.SystemSettingRepository
 import walter.y.bookeye.web.domain.system.setting.repository.SystemSettingRepositoryException
 import walter.y.bookeye.web.interfaceAdapter.gateway.env.system.setting.client.SystemSettingClient
 import walter.y.bookeye.web.interfaceAdapter.gateway.env.system.setting.client.SystemSettingClientException
+import walter.y.bookeye.web.interfaceAdapter.repository.annotation.Repository
 
 @Repository
 class SystemSettingRepositoryImpl(

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/system/version/SystemVersionRepositoryImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/system/version/SystemVersionRepositoryImpl.kt
@@ -1,11 +1,11 @@
 package walter.y.bookeye.web.interfaceAdapter.repository.system.version
 
-import org.springframework.stereotype.Repository
 import walter.y.bookeye.web.domain.system.version.model.SystemVersionEntity
 import walter.y.bookeye.web.domain.system.version.repository.SystemVersionRepository
 import walter.y.bookeye.web.domain.system.version.repository.SystemVersionRepositoryException
 import walter.y.bookeye.web.interfaceAdapter.gateway.env.system.version.client.SystemVersionClient
 import walter.y.bookeye.web.interfaceAdapter.gateway.env.system.version.client.SystemVersionClientException
+import walter.y.bookeye.web.interfaceAdapter.repository.annotation.Repository
 
 @Repository
 class SystemVersionRepositoryImpl(

--- a/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/user/account/UserAccountRepositoryImpl.kt
+++ b/server/web/src/main/kotlin/walter/y/bookeye/web/interfaceAdapter/repository/user/account/UserAccountRepositoryImpl.kt
@@ -1,13 +1,13 @@
 ﻿package walter.y.bookeye.web.interfaceAdapter.repository.user.account
 
 import org.springframework.security.crypto.password.PasswordEncoder
-import org.springframework.stereotype.Repository
 import walter.y.bookeye.web.domain.user.account.model.PrincipalName
 import walter.y.bookeye.web.domain.user.account.model.UserAccountEntity
 import walter.y.bookeye.web.domain.user.account.model.UserAccountId
 import walter.y.bookeye.web.domain.user.account.model.UserAccountPassword
 import walter.y.bookeye.web.domain.user.account.repository.UserAccountRepository
 import walter.y.bookeye.web.domain.user.model.UserId
+import walter.y.bookeye.web.interfaceAdapter.repository.annotation.Repository
 
 @Repository
 class UserAccountRepositoryImpl(

--- a/server/web/src/main/resources/application.yml
+++ b/server/web/src/main/resources/application.yml
@@ -1,8 +1,3 @@
-logging:
-  level:
-    root: ${WEB_LOGGING_LEVEL:INFO}
-    org.springframework: INFO
-
 app:
   api:
     password:
@@ -11,3 +6,17 @@ app:
     env:
       system-setting:
         access-key: ${SYSTEM_ACCESS_KEY:System-Access-Key-Used-4-Development-Only}
+
+spring:
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/book_eye
+    username: ${DATABASE_USER_NAME:root}
+    password: ${DATABASE_USER_PASSWORD:test}
+    hikari:
+      connection-test-query: SELECT 1
+
+logging:
+  level:
+    root: ${WEB_LOGGING_LEVEL:INFO}
+    org.springframework: INFO


### PR DESCRIPTION
## 概要
Spring JDBC の導入

## 変更内容
- Spring JDBC の導入
- Spring Bootのバージョンアップ
- build.gradle.kts の整理
- 専用のRepositoryアノテーションを追加

## 懸念事項
- Spring JDBC を使用する場合、Repository アノテーションにデータアクセスの責務が追加される
    - データアクセスは、Mapper に分離したいため、DIコンテナ管理用に同名の別アノテーションを用意

## やらないこと
- テーブルの接続
